### PR TITLE
Update project to agnostic python version controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,33 @@ Este repositório é para a primeira parte do Tutorial Avançado de Python. Para
 
 ## Dependências
 
-Para este projeto é requerido a versão do Python >= 3.8 e algumas dependências de desenvolvimento:
+Para este projeto é requerido a versão do Python >= 3.x e algumas dependências de desenvolvimento:
 
+### Ubuntu
 ```bash
-# entendendo que você deve usar Ubuntu
-$ sudo apt-get install python3.8
-$ sudo apt-get install python3.8-dev
+$ sudo apt-get install python3
+$ sudo apt-get install python3-dev
 ```
 
+### Mac OSX
+
+Baixe o instalador para Mac [neste link](https://www.python.org/downloads/macos/).
+
 ## Instalação
+
+Antes de mais nada, adicione ao projeto sua virtualenv e instale as dependências do projeto para desenvolvimento:
+
+```bash
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+$ python3 -m pip install -r requirements/dev.txt
+```
 
 Para instalar o módulo você deve usar o `setup.py` que já está configurado para tal:
 
 ```bash
-$ python3.8 setup.py build
-$ python3.8 setup.py install
+$ python3 setup.py build
+$ python3 setup.py install
 ```
 
 ## Testando a aplicação
@@ -32,7 +44,7 @@ $ python3.8 setup.py install
 Você pode testar a aplicação criando um arquivo que irá chamar as funções escritas em CPython ou executar os testes unitáris na pasta `tests/`.
 
 ```bash
-$ python3.8 -m unittest
+$ python3 -m unittest
 ```
 
 ## Autores

--- a/includes/elementary.h
+++ b/includes/elementary.h
@@ -2,7 +2,7 @@
 #define _H_PYCTUTORIAL_PYCALC_BASIC_
 #define PY_SSIZE_T_CLEAN
 
-#include <python3.8/Python.h>
+#include <Python.h>
 
 /* Funções do módulo */
 

--- a/includes/linalg.h
+++ b/includes/linalg.h
@@ -3,7 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include <math.h>
-#include <python3.8/Python.h>
+#include <Python.h>
 
 /* Funções do módulo */
 

--- a/includes/linalg.h
+++ b/includes/linalg.h
@@ -2,8 +2,8 @@
 #define _H_PYCTUTORIAL_PYCALC_BASIC_
 #define PY_SSIZE_T_CLEAN
 
-#include <math.h>
 #include <Python.h>
+#include <math.h>
 
 /* Funções do módulo */
 

--- a/includes/skeleton.h
+++ b/includes/skeleton.h
@@ -4,7 +4,7 @@
  * tamanho paassa a ser do tipo Py_ssize_t e não int */
 #define PY_SSIZE_T_CLEAN
 
-#include <python3.8/Python.h>
+#include <Python.h>
 
 /* uma lista com as funções que serão registradas no módulo */
 static PyMethodDef skeleton_ModuleMethods[] = {


### PR DESCRIPTION
# Introdução
Para tornar o tutorial mais abrangente, resolvi mudar a versão do python3.8 para uma versão agnóstica. Isso implicaria em alterar a documentação e os cabeçalhos dos arquivos `.c`. Também resolvi adicionar a instalação na documentação para o MacOSX.

# Mudanças
- removida a versão específica do python3.8 -> python3
- atualizada a documentação do projeto
- adicionado a documentação a instalação para MacOSX

---
Impacto: baixo